### PR TITLE
Fixing some typos and wrong text boxings

### DIFF
--- a/krypto/krypto.md
+++ b/krypto/krypto.md
@@ -146,8 +146,7 @@ Kollision.
 ### UTxO 1
 
 Sei $t_0 = (\emptyset, [0 \mapsto (a_0, 1000)])$ eine initiale
-Transaktion, mit UTxO = $\{(t_0, 0) \mapsto (a_0, 1000)\}$. Danach
-sie die folgende Transaktion ausgeführt worden
+Transaktion, mit UTxO = $\{(t_0, 0) \mapsto (a_0, 1000)\}$. Danach ist die folgende Transaktion ausgeführt worden
 
 $t_1 = (\{(t_0, 0)\}, [0 \mapsto (a_1, 50), 1 \mapsto (a_0, 950)])$
 

--- a/krypto/krypto.md
+++ b/krypto/krypto.md
@@ -208,7 +208,7 @@ Wie sieht dann die resultierende UTxO aus?
 
 Die beiden Antworten unterscheiden sich nur im zweiten Element und dort nur in der Adresse des Outputs. Das es die Transaktion $t_2$ ist, die diese neue UTxO erzeugt, muss dort auch auf diese Transaktion verwiesen werden.
 
-
+****
 
 # Haskell Referenzen
 

--- a/krypto/krypto.md
+++ b/krypto/krypto.md
@@ -164,7 +164,7 @@ Der Transaction Input $(t_0, 0)$ wird verbraucht und daraus werden in der Transa
 
 ### UTxO 2
 
-Sei $t_0 = (\emptyset, [0 \mapsto (a_0, 1000)])$ eine initiale Transaktion, mit UTxO = $\{(t_0, 0) \mapsto (a_0, 1000)\}$. Danach sie die folgende Transaktion ausgeführt worden
+Sei $t_0 = (\emptyset, [0 \mapsto (a_0, 1000)])$ eine initiale Transaktion, mit UTxO = $\{(t_0, 0) \mapsto (a_0, 1000)\}$. Danach ist die folgende Transaktion ausgeführt worden
 
 $t_1 = (\{(t_0, 0)\}, [0 \mapsto (a_1, 50), 1 \mapsto (a_0, 950)])$
 

--- a/krypto/krypto.md
+++ b/krypto/krypto.md
@@ -169,10 +169,6 @@ $t_1 = (\{(t_0, 0)\}, [0 \mapsto (a_1, 50), 1 \mapsto (a_0, 950)])$
 
 Wie sieht die neue UTxO aus?
 
-.. raw:: latex
-
-   \small
-
 [( )] $\{(t_0, 0) \mapsto (a_0, 1000), (t_1, 1) \mapsto (a_0, 950), (t_1, 0)  \mapsto (a_1, 50)\}$
 [(X)] $\{(t_1,0) \mapsto (a_0, 950), (t_1, 1) \mapsto (a_1, 50)\}$
 [( )] $\{(t_1,1) \mapsto (a_0, 950), (t_1, 0) \mapsto (a_1, 50)\}$


### PR DESCRIPTION
This fixes some Typos. 
As I have seen so far this is not the current status of the quiz (Commitments missing in this File). 
There is also a error in 

Pedersen Commitment 2

```
Wäre es nicht ausreichend wenn man nur $g^(r + m)$ nutzt, also keinen zweiten
```

turns out to only write the first bracket superscripted.