### PR TITLE
Update krypto.md

### DIFF
--- a/krypto/krypto.md
+++ b/krypto/krypto.md
@@ -166,7 +166,7 @@ Der Transaction Input $(t_0, 0)$ wird verbraucht und daraus werden in der Transa
 
 Sei $t_0 = (\emptyset, [0 \mapsto (a_0, 1000)])$ eine initiale Transaktion, mit UTxO = $\{(t_0, 0) \mapsto (a_0, 1000)\}$. Danach ist die folgende Transaktion ausgeführt worden
 
-$t_1 = (\{(t_0, 0)\}, [0 \mapsto (a_1, 50), 1 \mapsto (a_0, 950)])$
+$t_1 = (\{(t_0, 0)\}, [0 \mapsto (a_0, 950), 1 \mapsto (a_1, 50)])$
 
 Wie sieht die neue UTxO aus?
 


### PR DESCRIPTION
Lösung bei UTxO 2 war falsch zur Aufgabenstellung (die Aufgabenstellung von 1 war identisch zu 2)

Problemlösung: t1 richtig rum drehen.

P.s. das wurde alles noch nicht auf der Homepage ausgerollt, weil das Markdown da von http://mgu.cs.hm.edu/liascript/krypto.md ausgeliefert wird.